### PR TITLE
Fix gaussian GLMs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ciTools
 Type: Package
 Title: Confidence or Prediction Intervals, Quantiles, and Probabilities
     for Statistical Models
-Version: 0.2.1
+Version: 0.3.0
 Authors@R: c(person("John", "Haman", role = c("cre", "aut"),
     email = "mail@johnhaman.org"),
     person("Matthew", "Avery", role = "aut",

--- a/R/add_pi_glm.R
+++ b/R/add_pi_glm.R
@@ -28,7 +28,9 @@
 #' response is count data, prediction intervals are only
 #' approximate. Simulation from the QuasiPoisson model is performed
 #' with the negative binomial distribution, see Gelman and Hill
-#' (2007).
+#' (2007). Prediction intervals for Gaussian GLMs are also supported,
+#' but these intervals are no different than the ones returned by
+#' \code{add_pi.lm} if an identity link is used.
 #' 
 #' @param tb A tibble or data frame of new data.
 #' @param fit An object of class \code{glm}.

--- a/R/add_pi_glm.R
+++ b/R/add_pi_glm.R
@@ -42,7 +42,6 @@
 #'     named \code{names[1]} and the upper prediction bound will be
 #'     named \code{names[2]}.
 #' @param yhatName A string. Name of the predictions vector.
-#' @param type A string.
 #' @param nSims A positive integer. Determines the number of
 #'     simulations to run.
 #' @param ... Additional arguments.
@@ -70,7 +69,7 @@
 
 
 add_pi.glm <- function(tb, fit, alpha = 0.05, names = NULL, yhatName = "pred", 
-                       nSims = 2000, type = "boot", ...){
+                       nSims = 2000,  ...){
 
     if (is.null(names)) {
         names[1] <- paste("LPB", alpha/2, sep = "")
@@ -91,10 +90,10 @@ add_pi.glm <- function(tb, fit, alpha = 0.05, names = NULL, yhatName = "pred",
     if(fit$family$family %in% c("poisson", "quasipoisson"))
         warning("The response is not continuous, so Prediction Intervals are approximate")
 
-    if(!(fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial", "gaussian")))
+    if(!(fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial")))
         stop("Unsupported family")
 
-    if(fit$family$family == "gaussian" && type == "parametric") 
+    if(fit$family$family == "gaussian") 
         pi_gaussian(tb, fit, alpha, names, yhatName)
     else
         sim_pi_glm(tb, fit, alpha, names, yhatName, nSims)
@@ -133,7 +132,6 @@ sim_pi_glm <- function(tb, fit, alpha, names, yhatName, nSims){
     tb[[names[1]]] <- lwr
     tb[[names[2]]] <- upr
     tibble::as_data_frame(tb)
-
 }
 
 get_sim_response <- function(tb, fit, nSims){

--- a/R/add_pi_glm.R
+++ b/R/add_pi_glm.R
@@ -77,10 +77,10 @@ add_pi.glm <- function(tb, fit, alpha = 0.05, names = NULL, yhatName = "pred",
     }
     if ((names[1] %in% colnames(tb))) 
         warning ("These PIs may have already been appended to your dataframe. Overwriting.")
-
+    
         
     if(fit$family$family == "binomial")
-        if(max(fit$prior.weights) == 1)
+      if(max(fit$prior.weights) == 1)
           stop("Prediction intervals for Bernoulli response variables aren't useful")
       else {
           warning("Treating weights as indicating the number of trials for a binomial regression where the response is the proportion of successes")
@@ -96,7 +96,7 @@ add_pi.glm <- function(tb, fit, alpha = 0.05, names = NULL, yhatName = "pred",
     if(fit$family$family == "gaussian")
         pi_gaussian(tb, fit, alpha, names, yhatName)
     else
-        sim_pi_glm(tb, fit, alpha, names, yhatName, nSims)
+    sim_pi_glm(tb, fit, alpha, names, yhatName, nSims)
 }
 
 pi_gaussian <- function(tb, fit, alpha, names, yhatName){
@@ -121,7 +121,7 @@ sim_pi_glm <- function(tb, fit, alpha, names, yhatName, nSims){
     sim_response <- get_sim_response(tb, fit, nSims)
     lwr <- apply(sim_response, 1, FUN = quantile, probs = alpha/2, type = 1)
     upr <- apply(sim_response, 1, FUN = quantile, probs = 1 - alpha / 2, type = 1)
-
+    
     if(fit$family$family == "binomial"){
       out <- out * fit$prior.weights
       warning("For binomial models, add_pi's column of fitted values refelct E(Y|X) rather than typical default for logistic regression, pHat")
@@ -156,7 +156,7 @@ get_sim_response <- function(tb, fit, nSims){
             sim_response[,i] <- rnegbin(n = nPreds,
                                         mu = yhat,
                                         theta = a)
-            }
+        }
         if(response_distr == "Gamma"){
             sim_response[,i] <- rgamma(n = nPreds,
                                        shape = 1/overdisp,
@@ -168,6 +168,13 @@ get_sim_response <- function(tb, fit, nSims){
                                        size = fit$prior.weights,
                                        prob = yhat / fit$prior.weights)
         }
+        if(response_distr == "gaussian"){
+          yhat <- inverselink(modmat %*% sims@coef[i,])
+          sim_response[,i] <- rnorm(n = nPreds, 
+                                     mean = yhat,
+                                     sd = overdisp)
+        }
+        
     }
     sim_response
 }

--- a/R/add_pi_glm.R
+++ b/R/add_pi_glm.R
@@ -116,17 +116,15 @@ pi_gaussian <- function(tb, fit, alpha, names, yhatName){
 
 sim_pi_glm <- function(tb, fit, alpha, names, yhatName, nSims){
     out <- predict(fit, newdata = tb, type = "response")
-
     sim_response <- get_sim_response(tb, fit, nSims)
-
     lwr <- apply(sim_response, 1, FUN = quantile, probs = alpha/2, type = 1)
     upr <- apply(sim_response, 1, FUN = quantile, probs = 1 - alpha / 2, type = 1)
-    
 
     if(fit$family$family == "binomial"){
       out <- out * fit$prior.weights
       warning("For binomial models, add_pi's column of fitted values refelct E(Y|X) rather than typical default for logistic regression, pHat")
     }
+
     if(is.null(tb[[yhatName]]))
         tb[[yhatName]] <- out
     tb[[names[1]]] <- lwr

--- a/R/add_pi_glm.R
+++ b/R/add_pi_glm.R
@@ -90,7 +90,7 @@ add_pi.glm <- function(tb, fit, alpha = 0.05, names = NULL, yhatName = "pred",
     if(fit$family$family %in% c("poisson", "quasipoisson"))
         warning("The response is not continuous, so Prediction Intervals are approximate")
 
-    if(!(fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial")))
+    if(!(fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial", "gaussian")))
         stop("Unsupported family")
 
     if(fit$family$family == "gaussian") 

--- a/R/add_probs_glm.R
+++ b/R/add_probs_glm.R
@@ -34,6 +34,13 @@
 #'
 #' If \code{add_probs} is called on a logistic model, the fitted
 #' probabilities are used directly (no simulation is required).
+#'
+#' If \code{add_probs} is called on a Gaussian GLM, the returned
+#' probabilities are identical to those given by
+#' \code{add_probs.lm}. In this case, the comparisons \code{<} and
+#' \code{<=} are identical (likewise for \code{>} and \code{>=}). If
+#' the comparison \code{=} is used in the Gaussian GLM, an informative
+#' error is returned.
 #' 
 #' @param tb A tibble or data frame of new data.
 #' @param fit An object of class \code{glm}. Predictions are made with

--- a/R/add_probs_glm.R
+++ b/R/add_probs_glm.R
@@ -137,7 +137,7 @@ probs_gaussian <- function(tb, fit, q, name, yhatName, comparison){
     out <- predict(fit, newdata = tb, se.fit = TRUE)
     se_terms <- out$se.fit
     se_global <- sqrt(sigma_sq + se_terms^2)
-    t_quantile <- (q - out$fit) / se_global
+    t_quantile <- (q - inverselink(out$fit)) / se_global
 
     if (comparison %in% c("<", "<="))
         t_prob <- pt(q = t_quantile, df = fit$df.residual)

--- a/R/add_probs_glm.R
+++ b/R/add_probs_glm.R
@@ -51,6 +51,7 @@
 #'     the probabilities will be named \code{name} in the returned
 #'     tibble
 #' @param yhatName A string. Name of the vector of predictions.
+#' @param type A string.
 #' @param comparison A character vector of length one. If
 #'     \code{comparison = "<"}, then \eqn{Pr(Y|X < q)} is
 #'     calculated. Any comparison is allowed in Poisson regression,
@@ -91,7 +92,7 @@
 #' add_probs(cars, fit2, q = 1, comparison = "=")
 #' 
 #' @export
-add_probs.glm <- function(tb, fit, q, name = NULL, yhatName = "pred",
+add_probs.glm <- function(tb, fit, q, name = NULL, yhatName = "pred", type = "boot",
                           comparison = "<", nSims = 2000, ...){
 
     if (is.null(name) & (comparison == "<"))
@@ -120,15 +121,13 @@ add_probs.glm <- function(tb, fit, q, name = NULL, yhatName = "pred",
                   binomial regression where the response is the proportion of successes")
             sim_probs_other(tb, fit, q, name, yhatName, nSims, comparison)
         }
-        
-    } else if (fit$family$family %in% c("poisson", "qausipoisson", "Gamma")){
-        sim_probs_other(tb, fit, q, name, yhatName, nSims, comparison)
-    } else if (fit$family$family == "gaussian"){
+    } else if (fit$family$family == "gaussian" & type == "parametric"){
         probs_gaussian(tb, fit, q, name, yhatName, comparison)
+    } else if (fit$family$family %in% c("poisson", "qausipoisson", "Gamma", "gaussian")){
+        sim_probs_other(tb, fit, q, name, yhatName, nSims, comparison)
     } else {
         stop("Unsupported family")
     }
-
 }
 
 probs_gaussian <- function(tb, fit, q, name, yhatName, comparison){

--- a/R/add_probs_glm.R
+++ b/R/add_probs_glm.R
@@ -51,7 +51,6 @@
 #'     the probabilities will be named \code{name} in the returned
 #'     tibble
 #' @param yhatName A string. Name of the vector of predictions.
-#' @param type A string.
 #' @param comparison A character vector of length one. If
 #'     \code{comparison = "<"}, then \eqn{Pr(Y|X < q)} is
 #'     calculated. Any comparison is allowed in Poisson regression,
@@ -92,7 +91,7 @@
 #' add_probs(cars, fit2, q = 1, comparison = "=")
 #' 
 #' @export
-add_probs.glm <- function(tb, fit, q, name = NULL, yhatName = "pred", type = "boot",
+add_probs.glm <- function(tb, fit, q, name = NULL, yhatName = "pred",
                           comparison = "<", nSims = 2000, ...){
 
     if (is.null(name) & (comparison == "<"))
@@ -121,9 +120,9 @@ add_probs.glm <- function(tb, fit, q, name = NULL, yhatName = "pred", type = "bo
                   binomial regression where the response is the proportion of successes")
             sim_probs_other(tb, fit, q, name, yhatName, nSims, comparison)
         }
-    } else if (fit$family$family == "gaussian" & type == "parametric"){
+    } else if (fit$family$family == "gaussian"){
         probs_gaussian(tb, fit, q, name, yhatName, comparison)
-    } else if (fit$family$family %in% c("poisson", "qausipoisson", "Gamma", "gaussian")){
+    } else if (fit$family$family %in% c("poisson", "qausipoisson", "Gamma")){
         sim_probs_other(tb, fit, q, name, yhatName, nSims, comparison)
     } else {
         stop("Unsupported family")

--- a/R/add_probs_glm.R
+++ b/R/add_probs_glm.R
@@ -116,9 +116,9 @@ add_probs.glm <- function(tb, fit, q, name = NULL, yhatName = "pred",
           sim_probs_other(tb, fit, q, name, yhatName, nSims, comparison)
         }
     
-      } else{
-      if (fit$family$family %in% c("poisson", "qausipoisson"))
-        warning("The response is not continuous, so estimated probabilities are only approximate")
+    } else {
+        if (fit$family$family %in% c("poisson", "qausipoisson"))
+            warning("The response is not continuous, so estimated probabilities are only approximate")
         sim_probs_other(tb, fit, q, name, yhatName, nSims, comparison)
     }
 }

--- a/R/add_probs_lm.R
+++ b/R/add_probs_lm.R
@@ -89,7 +89,6 @@ add_probs.lm <- function(tb, fit, q, name = NULL, yhatName = "pred",
         t_prob <- 1 - pt(q = t_quantile, df = residual_df)
     if (is.null(tb[[yhatName]]))
         tb[[yhatName]] <- fitted
-    if (is.null(tb[[name]]))
-        tb[[name]] <- t_prob
+    tb[[name]] <- t_prob
     tibble::as_data_frame(tb)
 }

--- a/R/add_quantile_glm.R
+++ b/R/add_quantile_glm.R
@@ -44,7 +44,6 @@
 #'     quantiles automatically will be named by \code{add_quantile},
 #'     otherwise, they will be named \code{name}.
 #' @param yhatName A string. Name of the vector of predictions.
-#' @param type A string.
 #' @param nSims A positive integer. Set the number of simulated draws
 #'     to use.
 #' @param ... Additional arguments.
@@ -73,7 +72,7 @@
 #' 
 #' @export
 
-add_quantile.glm <- function(tb, fit, p, name = NULL, yhatName = "pred", type = "boot", 
+add_quantile.glm <- function(tb, fit, p, name = NULL, yhatName = "pred",
                              nSims = 2000, ...){
     if (p <= 0 || p >= 1)
         stop ("p should be in (0,1)")
@@ -85,18 +84,19 @@ add_quantile.glm <- function(tb, fit, p, name = NULL, yhatName = "pred", type = 
 
     if (fit$family$family == "binomial"){
         if(max(fit$prior.weights) == 1)
-        stop("Prediction intervals for Bernoulli response variables aren't useful") else {
-          warning("Treating weights as indicating the number of trials for a binomial regression where the response is the proportion of successes")
-          warning("The response variable is not continuous so Prediction Intervals are approximate")
+            stop("Prediction intervals for Bernoulli response variables aren't useful")
+        else {
+            warning("Treating weights as indicating the number of trials for a binomial regression where the response is the proportion of successes")
+            warning("The response variable is not continuous so Prediction Intervals are approximate")
         }
     }
 
     if (fit$family$family %in% c("poisson", "qausipoisson"))
         warning("The response is not continuous, so estimated quantiles are only approximate")
     
-    if (fit$family$family == "gaussian" & type == "parametric"){
+    if (fit$family$family == "gaussian"){
         quant_gaussian(tb, fit, p, name, yhatName)}
-    else if((fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial", "gaussian")))
+    else if((fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial")))
         sim_quantile_other(tb, fit, p, name, yhatName, nSims)
     else 
         stop("Unsupported family")

--- a/R/add_quantile_glm.R
+++ b/R/add_quantile_glm.R
@@ -93,10 +93,10 @@ add_quantile.glm <- function(tb, fit, p, name = NULL, yhatName = "pred",
     if (fit$family$family %in% c("poisson", "qausipoisson"))
         warning("The response is not continuous, so estimated quantiles are only approximate")
     
-    if((fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial"))){
+    if((fit$family$family %in% c("poisson", "quasipoisson", "Gamma", "binomial", "gaussian"))){
         sim_quantile_other(tb, fit, p, name, yhatName, nSims)
-    } else if (fit$family$family == "gaussian"){
-        quant_gaussian(tb, fit, p, name, yhatName)
+    # } else if (fit$family$family == "gaussian"){
+    #     quant_gaussian(tb, fit, p, name, yhatName)
     } else {
         stop("Unsupported family")
     }
@@ -109,7 +109,7 @@ quant_gaussian <- function(tb, fit, p, name, yhatName){
     se_terms <- out$se.fit
     t_quant <- qt(p = p, df = fit$df.residual, lower.tail = TRUE)
     se_global <- sqrt(sigma_sq + se_terms^2)
-    quant <- out$fit + t_quant * se_global
+    quant <- out$fit + t_quant * se_global #THIS IS WRONG. NEED TO FIGURE OUT THE CORRECT EXPRESSION
 
     if(is.null(tb[[yhatName]]))
         tb[[yhatName]] <- inverselink(out$fit)

--- a/R/add_quantile_glm.R
+++ b/R/add_quantile_glm.R
@@ -19,15 +19,21 @@
 #'
 #' This function is one of the methods of
 #' \code{add_quantile}. Currently, you can only use this function to
-#' compute the quantiles of the response of Poisson, Quasipoisson, or
-#' Gamma regression models.  Quantile estimates for Bernoulli response
-#' variables (i.e., logistic regression) are not supported.
+#' compute the quantiles of the response of Poisson, Quasipoisson,
+#' Gamma, or Gaussian regression models.  Quantile estimates for
+#' Bernoulli response variables (i.e., logistic regression) are not
+#' supported.
 #' 
 #' Quantiles of generalized linear models are determined by
 #' \code{add_quantile} through a simulation using \code{arm::sim}. If
 #' a Quasipoisson regression model is fit, simulation using the
 #' Negative Binomial distribution is performed, see Gelman and Hill
 #' (2007).
+#'
+#' If \code{add_quantile.glm} is called on a Gaussian GLM with
+#' identity link function, the returned quantiles are identical to
+#' those of \code{add_quantile.lm}. If a different link function is
+#' used, the appropriate inverse transformation is applied.
 #'
 #' @param tb A tibble or data frame of new data.
 #' @param fit An object of class \code{glm}. Predictions are made with

--- a/man/add_pi.glm.Rd
+++ b/man/add_pi.glm.Rd
@@ -45,7 +45,9 @@ Quasipoisson, and Gamma GLMs are supported. Note that if the
 response is count data, prediction intervals are only
 approximate. Simulation from the QuasiPoisson model is performed
 with the negative binomial distribution, see Gelman and Hill
-(2007).
+(2007). Prediction intervals for Gaussian GLMs are also supported,
+but these intervals are no different than the ones returned by
+\code{add_pi.lm} if an identity link is used.
 }
 \examples{
 # Fit a Poisson model

--- a/man/add_probs.glm.Rd
+++ b/man/add_probs.glm.Rd
@@ -56,6 +56,13 @@ model, a simulation is performed using \code{arm::sim}.
 
 If \code{add_probs} is called on a logistic model, the fitted
 probabilities are used directly (no simulation is required).
+
+If \code{add_probs} is called on a Gaussian GLM, the returned
+probabilities are identical to those given by
+\code{add_probs.lm}. In this case, the comparisons \code{<} and
+\code{<=} are identical (likewise for \code{>} and \code{>=}). If
+the comparison \code{=} is used in the Gaussian GLM, an informative
+error is returned.
 }
 \examples{
 # Fit a Poisson model

--- a/man/add_quantile.glm.Rd
+++ b/man/add_quantile.glm.Rd
@@ -34,9 +34,10 @@ A tibble, \code{tb}, with predicted values and level
 \description{
 This function is one of the methods of
 \code{add_quantile}. Currently, you can only use this function to
-compute the quantiles of the response of Poisson, Quasipoisson, or
-Gamma regression models.  Quantile estimates for Bernoulli response
-variables (i.e., logistic regression) are not supported.
+compute the quantiles of the response of Poisson, Quasipoisson,
+Gamma, or Gaussian regression models.  Quantile estimates for
+Bernoulli response variables (i.e., logistic regression) are not
+supported.
 }
 \details{
 Quantiles of generalized linear models are determined by
@@ -44,6 +45,11 @@ Quantiles of generalized linear models are determined by
 a Quasipoisson regression model is fit, simulation using the
 Negative Binomial distribution is performed, see Gelman and Hill
 (2007).
+
+If \code{add_quantile.glm} is called on a Gaussian GLM with
+identity link function, the returned quantiles are identical to
+those of \code{add_quantile.lm}. If a different link function is
+used, the appropriate inverse transformation is applied.
 }
 \examples{
 


### PR DESCRIPTION
These patches fix the issues raised by James Stewart regarding GLM regressions and the Gaussian family. Now when `family="gaussian"` is used in `glm`, the results from `add_{pi, probs, quantile}` will appear as if a linear model has been fit. 

Since we assume Normally distributed errors, the outputs of `add_{pi, probs, quantile}.lm` and `add_{pi, probs, quantile}.glm` agree when the link function is identity, even though the models are fit with two distinct algorithms.

Closes #14 