### PR TITLE
Only predict into levels that are fit in the model, and issue a warning when they are not available.  Also, enable ... to pass arguments to `boot::boot()`

### DIFF
--- a/man/add_ci.glm.Rd
+++ b/man/add_ci.glm.Rd
@@ -45,7 +45,7 @@ the method used to compute the confidence intervals.}
 \item{nSims}{An integer. Number of simulations to perform if the
 bootstrap method is used.}
 
-\item{...}{Additional arguments.}
+\item{...}{Additional arguments passed to \code{boot::boot()}.}
 }
 \value{
 A dataframe, \code{df}, with predicted values, upper and lower


### PR DESCRIPTION
This fixes #52 by setting factor levels to NA when they are not part of the data that are fit in the update.  (It should be compatible with PR #51 as it changes code below the model fitting while that PR changes code up to and including the model fitting.)