### PR TITLE
formula/model.frame fixes in add_ci_survreg

### DIFF
--- a/R/add_ci_survreg.R
+++ b/R/add_ci_survreg.R
@@ -175,8 +175,8 @@ parametric_ci_survreg_expectation <- function(df, fit,
     if (distr == "loglogistic" && (fit$scale >= 1))
         stop("Expected value is undefined for loglogistic distribution with scale >= 1")
 
-    form <- formula(fit)
-    m <- model.frame(form, df)
+    form <- delete.response(formula(fit))
+    m <- model.frame(form, df, xlev = fit$xlevels)
     mat <- model.matrix(form, m)
 
 
@@ -243,8 +243,8 @@ surv_boot_mean <- function(df, fit){
         return(pred)
     }
 
-    form <- formula(fit)
-    m <- model.frame(form, df)
+    form <- delete.response(formula(fit))
+    m <- model.frame(form, df, xlev = fit$xlevels)
     mat <- model.matrix(form, m)
     nPred <- dim(df)[1]
     beta <- coef(fit)
@@ -266,8 +266,8 @@ boot_ci_survreg_expectation <- function(df, fit,
     if (distr == "loglogistic" && (fit$scale >= 1))
         stop("Expected value is undefined for loglogistic distribution with scale >= 1")
 
-    form <- formula(fit)
-    m <- model.frame(form, df)
+    form <- delete.response(formula(fit))
+    m <- model.frame(form, df, xlev = fit$xlevels)
     mat <- model.matrix(form, m)
 
     if(any(is.na(mat)))


### PR DESCRIPTION
Deleted response from extracted formula so unnecessary response column
isn't required in new data.  Specified x-levels in model.frame to
increase robustness to incorrectly ordered factors in new data.